### PR TITLE
Only add the inline script if there is one

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,13 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-------------------
-## [1.3.5] - 2026-06-11
 ### Fixed
 
 * Fixed a PHP 8.1+ deprecation warning (`stripos(): Passing null to parameter #1`) caused by passing `null` to `wp_add_inline_script` when the HelpScout beacon is disabled.
 
+------------------
 ## [1.3.4] - 2026-04-23
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ------------------
+## [1.3.5] - 2026-06-11
+### Fixed
+
+* Fixed a PHP 8.1+ deprecation warning (`stripos(): Passing null to parameter #1`) caused by passing `null` to `wp_add_inline_script` when the HelpScout beacon is disabled.
+
 ## [1.3.4] - 2026-04-23
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "krokedil/settings-page",
     "description": "A package to help setup settings pages in WordPress and WooCommerce for Krokedil plugins to add the Addons and Support tabs",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "type": "library",
     "require-dev": {
         "wp-coding-standards/wpcs": "dev-develop",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "krokedil/settings-page",
     "description": "A package to help setup settings pages in WordPress and WooCommerce for Krokedil plugins to add the Addons and Support tabs",
-    "version": "1.3.5",
+    "version": "1.3.4",
     "type": "library",
     "require-dev": {
         "wp-coding-standards/wpcs": "dev-develop",

--- a/src/Support.php
+++ b/src/Support.php
@@ -38,11 +38,11 @@ class Support {
 	 * Return the Helpscout beacon script.
 	 *
 	 * @param string $use_helpscout Whether to include the Helpscout beacon.
-	 * @return string|null
+	 * @return string
 	 */
 	public static function hs_beacon_script( $use_helpscout = 'no' ) {
 		if ( 'yes' !== $use_helpscout ) {
-			return;
+			return '';
 		}
 
 		return '!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});';
@@ -80,12 +80,15 @@ class Support {
 			)
 		);
 
-		// Load JS.
-		wp_add_inline_script(
-			'krokedil-support-page',
-			self::hs_beacon_script( $this->support['use_helpscout'] ?? 'yes' ),
-			'before',
-		);
+		// Load JS. Only add the inline script if there is one, since wp_add_inline_script does not accept empty data.
+		$beacon_script = self::hs_beacon_script( $this->support['use_helpscout'] ?? 'yes' );
+		if ( ! empty( $beacon_script ) ) {
+			wp_add_inline_script(
+				'krokedil-support-page',
+				$beacon_script,
+				'before',
+			);
+		}
 		wp_enqueue_script( 'krokedil-support-page' );
 	}
 


### PR DESCRIPTION
* Fixed a PHP 8.1+ deprecation warning (`stripos(): Passing null to parameter #1`) caused by passing `null` to `wp_add_inline_script` when the HelpScout beacon is disabled.